### PR TITLE
Update API

### DIFF
--- a/lib/fastlane/plugin/perfecto/actions/perfecto_action.rb
+++ b/lib/fastlane/plugin/perfecto/actions/perfecto_action.rb
@@ -16,6 +16,7 @@ module Fastlane
         perfecto_token = params[:perfecto_token]
         filepath = params[:file_path].to_s
         perfecto_media_fullpath = params[:perfecto_media_location]
+        perfecto_artifact_type = params[:perfecto_artifact_type]
 
         # validates the filepath and perfecto media location file
         UI.message("validating filepath")
@@ -25,7 +26,7 @@ module Fastlane
 
         # uploads the ipa/apk to perfecto media repository
         UI.message("Attempting to upload: " + filepath + " to Perfecto!")
-        Helper::PerfectoHelper.upload_file(perfecto_cloudurl, perfecto_token, filepath, perfecto_media_fullpath)
+        Helper::PerfectoHelper.upload_file(perfecto_cloudurl, perfecto_token, filepath, perfecto_media_fullpath, perfecto_artifact_type)
         UI.success("The File in: " + filepath + " is successfully uploaded to Perfecto media location : " + perfecto_media_fullpath)
 
         # Setting the environment variable: PERFECTO_MEDIA_FULLPATH with the perfecto media repository location.
@@ -118,7 +119,12 @@ module Fastlane
                                        description: "Path to the app file",
                                        optional: true,
                                        is_string: true,
-                                       default_value: default_file_path)
+                                       default_value: default_file_path),
+          FastlaneCore::ConfigItem.new(key: :perfecto_artifact_type,
+                                       description: "Type of the artifact (GENERAL, IOS, SIMULATOR, ANDROID, IMAGE, AUDIO, VIDEO, SCRIPT)",
+                                       optional: true,
+                                       is_string: true,
+                                       default_value: "")
         ]
       end
 
@@ -133,7 +139,8 @@ module Fastlane
             perfecto_cloudurl: ENV["PERFECTO_CLOUDURL"],
             perfecto_token: ENV["PERFECTO_TOKEN"],
             perfecto_media_location: ENV["PERFECTO_MEDIA_LOCATION"],
-            file_path: "path_to_apk_or_ipa_file"
+            file_path: "path_to_apk_or_ipa_file",
+            perfecto_artifact_type: "ANDROID"
            )'
         ]
       end

--- a/lib/fastlane/plugin/perfecto/helper/perfecto_helper.rb
+++ b/lib/fastlane/plugin/perfecto/helper/perfecto_helper.rb
@@ -18,15 +18,24 @@ module Fastlane
         unless ENV['http_proxy']
           RestClient.proxy = ENV['http_proxy']
         end
+        uri = URI.parse(perfecto_cloudurl)
         response = RestClient::Request.execute(
-          url: 'https://' + perfecto_cloudurl + '/services/repositories/media/' + perfecto_media_fullpath + '?operation=upload&overwrite=true&securityToken=' + URI.encode(perfecto_token, "UTF-8"),
+          url: 'https://' + uri.host + '/repository/api/v1/artifacts',
           method: :post,
           headers: {
             'Accept' => 'application/json',
-            'Content-Type' => 'application/octet-stream',
-            'Expect' => '100-continue'
+            'Content-Type' => 'multipart/form-data',
+            'PERFECTO_AUTHORIZATION' => perfecto_token
           },
-          payload: File.open(file_path, "rb")
+          payload: {
+            multipart: true,
+            inputStream: File.open(file_path, "rb"),
+            requestPart: {
+              artifactLocator: "PUBLIC:BUILDS/EMS/EMS_QA/app-release.qa.apk",
+              artifactType: "ANDROID",
+              override: true
+            }.to_json
+          }
         )
         UI.message(response.inspect)
       rescue RestClient::ExceptionWithResponse => err

--- a/lib/fastlane/plugin/perfecto/helper/perfecto_helper.rb
+++ b/lib/fastlane/plugin/perfecto/helper/perfecto_helper.rb
@@ -31,8 +31,7 @@ module Fastlane
             multipart: true,
             inputStream: File.open(file_path, "rb"),
             requestPart: {
-              artifactLocator: "PUBLIC:BUILDS/EMS/EMS_QA/app-release.qa.apk",
-              artifactType: "ANDROID",
+              artifactLocator: perfecto_media_fullpath,
               override: true
             }.to_json
           }

--- a/lib/fastlane/plugin/perfecto/helper/perfecto_helper.rb
+++ b/lib/fastlane/plugin/perfecto/helper/perfecto_helper.rb
@@ -14,7 +14,8 @@ module Fastlane
       # +perfecto_token+:: Perfecto's security token.
       # +file_path+:: Path to the file to be uploaded.
       # +perfecto_media_fullpath+:: Path to the perfecto media location
-      def self.upload_file(perfecto_cloudurl, perfecto_token, file_path, perfecto_media_fullpath)
+      # +perfecto_artifact_type+:: GENERAL, IOS, SIMULATOR, ANDROID, IMAGE, AUDIO, VIDEO, SCRIPT
+      def self.upload_file(perfecto_cloudurl, perfecto_token, file_path, perfecto_media_fullpath, perfecto_artifact_type)
         unless ENV['http_proxy']
           RestClient.proxy = ENV['http_proxy']
         end
@@ -32,6 +33,7 @@ module Fastlane
             inputStream: File.open(file_path, "rb"),
             requestPart: {
               artifactLocator: perfecto_media_fullpath,
+              artifactType: perfecto_artifact_type,
               override: true
             }.to_json
           }

--- a/lib/fastlane/plugin/perfecto/version.rb
+++ b/lib/fastlane/plugin/perfecto/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Perfecto
-    VERSION = "0.1.1"
+    VERSION = "0.1.2"
   end
 end


### PR DESCRIPTION
This supports the new API per: https://developers.perfectomobile.com/display/PD/Upload+Item+to+Repository

I'm using my fork in a build process and it works fine.

Maybe should also add an "artifact_type" parameter per the API doc, which is optional.

Also updated the URI construction to resolve issues where someone passes in "https://mycloud.app.perfectomobile.com", which blows up because the URI is then invalid and you'd never know why without looking at the plugin source.